### PR TITLE
fix: type for resolved value

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
 export default function safeAwait<T>(
   promise: Promise<T>,
   finallyFunc?: Function
-): Promise<[error: any, data: T]>;
+): Promise<[error: Error] | [error: undefined, data: T]>;


### PR DESCRIPTION
Found out that the type declaration for the resolving value is not actually correct. 

According to the source code, there are two kinds of resolve
1. [error]  = [error,`undefined`]
2. [`undefined`, data] 

The type for error and data should be both optional. e.g. `[error?: Error, data?: T]`

I choose to use `[error: Error] | [error: undefined, data: T]` instead because this is what it actually resolved

